### PR TITLE
Remove recursion when creating Tasks

### DIFF
--- a/src/main/kotlin/com/github/andre2w/pedreiro/blueprints/BlueprintService.kt
+++ b/src/main/kotlin/com/github/andre2w/pedreiro/blueprints/BlueprintService.kt
@@ -1,11 +1,7 @@
 package com.github.andre2w.pedreiro.blueprints
 
 import com.github.andre2w.pedreiro.Arguments
-import com.github.andre2w.pedreiro.environment.ConsoleHandler
-import com.github.andre2w.pedreiro.environment.FileSystemHandler
-import com.github.andre2w.pedreiro.environment.LocalEnvironment
-import com.github.andre2w.pedreiro.environment.ProcessExecutor
-import com.github.andre2w.pedreiro.tasks.*
+import com.github.andre2w.pedreiro.tasks.Tasks
 import com.github.andre2w.pedreiro.yaml.InvalidNodeType
 import com.github.andre2w.pedreiro.yaml.YamlNode
 import com.github.andre2w.pedreiro.yaml.YamlParser
@@ -16,82 +12,21 @@ import javax.inject.Singleton
 @Singleton
 class BlueprintService(
     private val blueprintReader: BlueprintReader,
-    private val fileSystemHandler: FileSystemHandler,
-    private val environment: LocalEnvironment,
-    private val processExecutor: ProcessExecutor,
-    private val consoleHandler: ConsoleHandler,
-    private val yamlParser: YamlParser
+    private val yamlParser: YamlParser,
+    private val taskFactory: TaskFactory
 ) {
 
     fun loadBlueprint(arguments: Arguments): Tasks {
         val blueprint = blueprintReader.read(arguments)
-
         val blueprintTasks = try {
             yamlParser.parse(blueprint.tasks)
         } catch (err: ParserException) {
             throw BlueprintParsingException("Failed to parse blueprint ${arguments.blueprintName}")
         }
-
-        val parseableObjects = parseableObject(blueprintTasks)
-
-        return parseableObjects
-            .map { parseObject(it.node, it.level, blueprint) }
+        return toParsingObject(blueprintTasks)
+            .map { taskFactory.create(it.node, it.level, blueprint) }
             .let(Tasks.Companion::from)
     }
-
-    private fun parseObject(yamlNode: YamlNode.Object, level: List<String>, blueprint: Blueprint): Task {
-        return when (val objectType = yamlNode.textValue("type")) {
-            "command" -> parseCommand(level.asPath(), yamlNode)
-            "file" -> parseCreateFile(level.asPath(), blueprint, yamlNode)
-            "folder" -> parseCreateFolder(level, yamlNode)
-            else -> throw BlueprintParsingException("Invalid type of $objectType")
-        }
-    }
-
-    private fun parseCreateFolder(level: List<String>, yamlNode: YamlNode.Object): Task {
-        val currentLevel = level + yamlNode.textValue("name")
-        return createFolderWith(currentLevel)
-    }
-
-    private fun parseCreateFile(path: String, blueprint: Blueprint, yamlNode: YamlNode.Object): Task {
-        val filePath = if (path == "") {
-            yamlNode.textValue("name")
-        } else {
-            path + "/" + yamlNode.textValue("name")
-        }
-
-        val content = when (val contentNode = yamlNode["content"]) {
-            is YamlNode.Value -> contentNode.asText()
-            is YamlNode.Missing -> blueprint.fileContentOf(yamlNode.textValue("source"))
-            else -> throw InvalidNodeType("Folder type should have text in content field or source pointing to a file")
-        }
-
-        return createFileWith(filePath, content)
-    }
-
-    private fun parseCommand(path: String, yamlNode: YamlNode.Object): Task {
-        val platform = consoleHandler.currentPlatform()
-        val command = when (val node = yamlNode[platform.shortName]) {
-            is YamlNode.Value -> node.asText()
-            else -> yamlNode.textValue("command")
-        }
-        return ExecuteCommand(command, path, processExecutor, environment)
-    }
-
-    private fun createFolderWith(currentLevel: List<String>): CreateFolder {
-        return CreateFolder(
-            currentLevel.asPath(),
-            fileSystemHandler,
-            environment,
-            consoleHandler
-        )
-    }
-
-    private fun createFileWith(filePath: String, content: String): CreateFile {
-        return CreateFile(filePath, content, fileSystemHandler, environment, consoleHandler)
-    }
-
-    private fun List<String>.asPath() = this.joinToString("/")
 
     private fun YamlNode.Object.textValue(field: String): String {
         return when (val typeNode = this[field]) {
@@ -100,28 +35,24 @@ class BlueprintService(
         }
     }
 
-    private fun parseableObject(node: YamlNode, level: List<String> = emptyList()): List<ParseableObject> {
-        val result = LinkedList<ParseableObject>()
-
+    private fun toParsingObject(node: YamlNode, level: List<String> = emptyList()): List<ParsingObject> {
+        val result = LinkedList<ParsingObject>()
         val list = when (node) {
             is YamlNode.Object -> parseSingleObject(node, level)
-            is YamlNode.List -> node.flatMap { parseableObject(it, level) }
+            is YamlNode.List -> node.flatMap { toParsingObject(it, level) }
             else -> emptyList()
         }
-
         result.addAll(list)
-
         return result
     }
 
-    private fun parseSingleObject(node: YamlNode.Object, level: List<String>): List<ParseableObject> {
-        val result = LinkedList<ParseableObject>()
-
-        result.add(ParseableObject(level, node))
+    private fun parseSingleObject(node: YamlNode.Object, level: List<String>): List<ParsingObject> {
+        val result = LinkedList<ParsingObject>()
+        result.add(ParsingObject(level, node))
 
         if (node.textValue("type") == "folder") {
             val children = when (val child = node["children"]) {
-                is YamlNode.List -> child.flatMap { parseableObject(it, level + node.textValue("name")) }
+                is YamlNode.List -> child.flatMap { toParsingObject(it, level + node.textValue("name")) }
                 else -> emptyList()
             }
             result.addAll(children)
@@ -131,7 +62,7 @@ class BlueprintService(
     }
 }
 
-data class ParseableObject(
+data class ParsingObject(
     val level: List<String>,
     val node: YamlNode.Object
 )

--- a/src/main/kotlin/com/github/andre2w/pedreiro/blueprints/BlueprintService.kt
+++ b/src/main/kotlin/com/github/andre2w/pedreiro/blueprints/BlueprintService.kt
@@ -10,12 +10,8 @@ import com.github.andre2w.pedreiro.yaml.InvalidNodeType
 import com.github.andre2w.pedreiro.yaml.YamlNode
 import com.github.andre2w.pedreiro.yaml.YamlParser
 import org.yaml.snakeyaml.parser.ParserException
+import java.util.*
 import javax.inject.Singleton
-
-sealed class ParseResult {
-    data class Single(val task: Task) : ParseResult()
-    data class Many(val tasks: List<Task>) : ParseResult()
-}
 
 @Singleton
 class BlueprintService(
@@ -36,66 +32,28 @@ class BlueprintService(
             throw BlueprintParsingException("Failed to parse blueprint ${arguments.blueprintName}")
         }
 
-        return Tasks.from(parse(blueprintTasks, blueprint))
+        val parseableObjects = parseableObject(blueprintTasks)
+
+        return parseableObjects
+            .map { parseObject(it.node, it.level, blueprint) }
+            .let(Tasks.Companion::from)
     }
 
-    private fun parse(
-        yamlNode: YamlNode,
-        blueprint: Blueprint,
-        level: List<String> = ArrayList()
-    ): List<Task> {
-        return when (yamlNode) {
-            is YamlNode.List -> parseList(level, blueprint, yamlNode)
-            is YamlNode.Object -> parseObject(yamlNode, level, blueprint)
-            else -> throw IllegalStateException()
-        }
-    }
-
-    private fun parseObject(yamlNode: YamlNode.Object, level: List<String>, blueprint: Blueprint): List<Task> {
-
-        val parsedResult = when (val objectType = yamlNode.textValue("type")) {
+    private fun parseObject(yamlNode: YamlNode.Object, level: List<String>, blueprint: Blueprint): Task {
+        return when (val objectType = yamlNode.textValue("type")) {
             "command" -> parseCommand(level.asPath(), yamlNode)
             "file" -> parseCreateFile(level.asPath(), blueprint, yamlNode)
-            "folder" -> parseCreateFolder(level, blueprint, yamlNode)
+            "folder" -> parseCreateFolder(level, yamlNode)
             else -> throw BlueprintParsingException("Invalid type of $objectType")
         }
-
-        return when (parsedResult) {
-            is ParseResult.Many -> parsedResult.tasks
-            is ParseResult.Single -> listOf(parsedResult.task)
-        }
     }
 
-    private fun parseList(level: List<String>, blueprint: Blueprint, yamlNode: YamlNode.List) =
-        yamlNode.flatMap { node -> parse(node, blueprint, level) }
-
-    private fun parseCreateFolder(
-        level: List<String>,
-        blueprint: Blueprint,
-        yamlNode: YamlNode.Object
-    ): ParseResult.Many {
-        val result = ArrayList<Task>()
-
+    private fun parseCreateFolder(level: List<String>, yamlNode: YamlNode.Object): Task {
         val currentLevel = level + yamlNode.textValue("name")
-
-        result.add(createFolderWith(currentLevel))
-
-        val childTasks = when (val children = yamlNode["children"]) {
-            is YamlNode.List -> parseList(currentLevel, blueprint, children)
-            is YamlNode.Missing -> emptyList()
-            else -> throw InvalidNodeType("children field should have have a list")
-        }
-        result.addAll(childTasks)
-
-        return ParseResult.Many(result)
+        return createFolderWith(currentLevel)
     }
 
-    private fun parseCreateFile(
-        path: String,
-        blueprint: Blueprint,
-        yamlNode: YamlNode.Object
-    ): ParseResult.Single {
-
+    private fun parseCreateFile(path: String, blueprint: Blueprint, yamlNode: YamlNode.Object): Task {
         val filePath = if (path == "") {
             yamlNode.textValue("name")
         } else {
@@ -108,18 +66,16 @@ class BlueprintService(
             else -> throw InvalidNodeType("Folder type should have text in content field or source pointing to a file")
         }
 
-        val createFile = createFileWith(filePath, content)
-
-        return ParseResult.Single(createFile)
+        return createFileWith(filePath, content)
     }
 
-    private fun parseCommand(path: String, yamlNode: YamlNode.Object): ParseResult.Single {
+    private fun parseCommand(path: String, yamlNode: YamlNode.Object): Task {
         val platform = consoleHandler.currentPlatform()
         val command = when (val node = yamlNode[platform.shortName]) {
             is YamlNode.Value -> node.asText()
             else -> yamlNode.textValue("command")
         }
-        return ParseResult.Single(ExecuteCommand(command, path, processExecutor, environment))
+        return ExecuteCommand(command, path, processExecutor, environment)
     }
 
     private fun createFolderWith(currentLevel: List<String>): CreateFolder {
@@ -132,13 +88,7 @@ class BlueprintService(
     }
 
     private fun createFileWith(filePath: String, content: String): CreateFile {
-        return CreateFile(
-            filePath,
-            content,
-            fileSystemHandler,
-            environment,
-            consoleHandler
-        )
+        return CreateFile(filePath, content, fileSystemHandler, environment, consoleHandler)
     }
 
     private fun List<String>.asPath() = this.joinToString("/")
@@ -149,4 +99,39 @@ class BlueprintService(
             else -> throw InvalidNodeType("Type must contain a string, found: $typeNode")
         }
     }
+
+    private fun parseableObject(node: YamlNode, level: List<String> = emptyList()): List<ParseableObject> {
+        val result = LinkedList<ParseableObject>()
+
+        val list = when (node) {
+            is YamlNode.Object -> parseSingleObject(node, level)
+            is YamlNode.List -> node.flatMap { parseableObject(it, level) }
+            else -> emptyList()
+        }
+
+        result.addAll(list)
+
+        return result
+    }
+
+    private fun parseSingleObject(node: YamlNode.Object, level: List<String>): List<ParseableObject> {
+        val result = LinkedList<ParseableObject>()
+
+        result.add(ParseableObject(level, node))
+
+        if (node.textValue("type") == "folder") {
+            val children = when (val child = node["children"]) {
+                is YamlNode.List -> child.flatMap { parseableObject(it, level + node.textValue("name")) }
+                else -> emptyList()
+            }
+            result.addAll(children)
+        }
+
+        return result
+    }
 }
+
+data class ParseableObject(
+    val level: List<String>,
+    val node: YamlNode.Object
+)

--- a/src/main/kotlin/com/github/andre2w/pedreiro/blueprints/TaskFactory.kt
+++ b/src/main/kotlin/com/github/andre2w/pedreiro/blueprints/TaskFactory.kt
@@ -1,0 +1,83 @@
+package com.github.andre2w.pedreiro.blueprints
+
+import com.github.andre2w.pedreiro.environment.ConsoleHandler
+import com.github.andre2w.pedreiro.environment.FileSystemHandler
+import com.github.andre2w.pedreiro.environment.LocalEnvironment
+import com.github.andre2w.pedreiro.environment.ProcessExecutor
+import com.github.andre2w.pedreiro.tasks.CreateFile
+import com.github.andre2w.pedreiro.tasks.CreateFolder
+import com.github.andre2w.pedreiro.tasks.ExecuteCommand
+import com.github.andre2w.pedreiro.tasks.Task
+import com.github.andre2w.pedreiro.yaml.InvalidNodeType
+import com.github.andre2w.pedreiro.yaml.YamlNode
+import javax.inject.Singleton
+
+@Singleton
+class TaskFactory(
+    private val consoleHandler: ConsoleHandler,
+    private val fileSystemHandler: FileSystemHandler,
+    private val environment: LocalEnvironment,
+    private val processExecutor: ProcessExecutor
+) {
+
+    fun create(yamlNode: YamlNode.Object, level: List<String>, blueprint: Blueprint): Task {
+        return when (val objectType = yamlNode.textValue("type")) {
+            "command" -> parseCommand(level.asPath(), yamlNode)
+            "file" -> parseCreateFile(level.asPath(), blueprint, yamlNode)
+            "folder" -> parseCreateFolder(level, yamlNode)
+            else -> throw BlueprintParsingException("Invalid type of $objectType")
+        }
+    }
+
+    private fun parseCreateFolder(level: List<String>, yamlNode: YamlNode.Object): Task {
+        val currentLevel = level + yamlNode.textValue("name")
+        return createFolderWith(currentLevel)
+    }
+
+    private fun parseCreateFile(path: String, blueprint: Blueprint, yamlNode: YamlNode.Object): Task {
+        val filePath = if (path == "") {
+            yamlNode.textValue("name")
+        } else {
+            path + "/" + yamlNode.textValue("name")
+        }
+
+        val content = when (val contentNode = yamlNode["content"]) {
+            is YamlNode.Value -> contentNode.asText()
+            is YamlNode.Missing -> blueprint.fileContentOf(yamlNode.textValue("source"))
+            else -> throw InvalidNodeType("Folder type should have text in content field or source pointing to a file")
+        }
+
+        return createFileWith(filePath, content)
+    }
+
+    private fun parseCommand(path: String, yamlNode: YamlNode.Object): Task {
+        val platform = consoleHandler.currentPlatform()
+        val command = when (val node = yamlNode[platform.shortName]) {
+            is YamlNode.Value -> node.asText()
+            else -> yamlNode.textValue("command")
+        }
+        return ExecuteCommand(command, path, processExecutor, environment)
+    }
+
+    private fun createFolderWith(currentLevel: List<String>): CreateFolder {
+        return CreateFolder(
+            currentLevel.asPath(),
+            fileSystemHandler,
+            environment,
+            consoleHandler
+        )
+    }
+
+    private fun createFileWith(filePath: String, content: String): CreateFile {
+        return CreateFile(filePath, content, fileSystemHandler, environment, consoleHandler)
+    }
+
+    private fun List<String>.asPath() = this.joinToString("/")
+
+    private fun YamlNode.Object.textValue(field: String): String {
+        return when (val typeNode = this[field]) {
+            is YamlNode.Value -> typeNode.asText()
+            else -> throw InvalidNodeType("Type must contain a string, found: $typeNode")
+        }
+    }
+}

--- a/src/test/kotlin/com/github/andre2w/pedreiro/blueprints/BlueprintServiceShould.kt
+++ b/src/test/kotlin/com/github/andre2w/pedreiro/blueprints/BlueprintServiceShould.kt
@@ -26,7 +26,8 @@ class BlueprintServiceShould {
     private val configurationManager = mockk<ConfigurationManager>()
     private val consoleHandler = mockk<ConsoleHandler>()
     private val configuration = PedreiroConfiguration("/home/user/pedreiro/.pedreiro/blueprints")
-    private val blueprintService = BlueprintService(blueprintReader, fileSystemHandler, environment, processExecutor, consoleHandler, YamlParser())
+    private val taskFactory = TaskFactory(consoleHandler, fileSystemHandler, environment, processExecutor)
+    private val blueprintService = BlueprintService(blueprintReader, YamlParser(), taskFactory)
 
     @BeforeEach
     fun setUp() {


### PR DESCRIPTION
This is the first change to split the BlueprintService from
the creation of the Tasks, now a ParseableObject (name to be
changed) will be created and then we will create the Task from it.